### PR TITLE
implements IgnoreHtmlNoise feature to the lexer

### DIFF
--- a/src/Scriban/Parsing/LexerOptions.cs
+++ b/src/Scriban/Parsing/LexerOptions.cs
@@ -43,5 +43,11 @@ namespace Scriban.Parsing
         /// The lexer will return whitespaces tokens
         /// </summary>
         public bool KeepTrivia { get; set; }
+
+        /// <summary>
+        /// The lexer will ignore HTML-Tags and HTML-Entities within code blocks.
+        /// Newlines are ignored, too. br-Tags and closing p-Tags are converted into newlines.
+        /// </summary>
+        public bool IgnoreHtmlNoise { get; set; }
     }
 }


### PR DESCRIPTION
This feature is about enabling scriban templates to be edited with WYSIWIG HTML-Editors.
Using such an editor for editing leads to unparseable scriban blocks due to html code noise and unpredictable line breaks.

Consider the following simple sample:
```
This is a test for {{ 'scriban' }}: 
{{  a=5; 
    b = 3;
    a+b;
}}
```

The HTML-Code resulting from this input can easily be like the follwing:
```
<html>This is a test for {{ <span class="name">
'scriban'</span>&nbsp;}}: {{ &nbsp;a=5;<br> &nbsp;&nbsp;&nbsp;b 
= 3; 
 &nbsp;&nbsp;&nbsp;a
+b;
}}
```

obviously this will not be parseable by scriban at all.
But my changes will enable correct parsing when `LexerOptions.IgnoreHtmlNoise = true;` is set.

The following will apply within code-blocks which are not strings:
 - newlines within are ignored (parsed as whitespace)
 - HTML-Tags commonly used for newline are interpreted as newlines `<br>, </p>`
 - all other HTML-Tags are ignored (parsed as comment)
 - HTML-Entities (e.g. `&nbsp;`) are ignored (parsed as comment)

There are caveats which can be circumvented:
1) The html-opening tag (`<`) collides with the less-then operator.
 - when followed by a space `< ` or digit `<4` it will be interpreted as operator
2) When writing multi-line blocks, you should end every expression with a semi-colon.

One thing more:
I have absolutely minor experience with GIT. Please forgive me if I did something wrong posting this pull-request.