### PR TITLE
Port unit tests to more frameworks et al.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ var template = Template.ParseLiquid("Hello {{name}}!");
 var result = template.Render(new { Name = "World" }); // => "Hello World!" 
 ```
 
-The language is very versatile, easy to read and use, similar to [liquid](http://liquidmarkup.org/) templates:
+The language is very versatile, easy to read and use, similar to [liquid](https://shopify.github.io/liquid/) templates:
 
 ```C#
 var template = Template.Parse(@"
@@ -89,13 +89,13 @@ Scriban is available as a NuGet package: [![NuGet](https://img.shields.io/nuget/
 
 Compatible with the following .NET framework profiles:
 
-- `.NET3.5`
-- `.NET4.0+`
--  .NET PCL profile `portable40-net40+sl5+win8+wp8+wpa81`
-- `UAP10.0+`
-- `NetStandard1.1+` and `NetStandard1.3+` running on `CoreCLR`
+- .NET Framework 3.5
+- .NET Framework 4.0
+- .NET Framework 4.5+ (supports asynchronous code and timeouts for regular expressions)
+- .NET Standard1.1+ (some features are not available)
+- .NET Standard1.3+ (which means .NET Core, Xamarin, UWP, Unity etc.)
 
-Also [Scriban.Signed](https://www.nuget.org/packages/Scriban.Signed/) NuGet package provides signed assemblies.
+Also the [Scriban.Signed](https://www.nuget.org/packages/Scriban.Signed/) NuGet package provides signed assemblies.
 
 ## Benchmarks
 
@@ -103,7 +103,7 @@ Also [Scriban.Signed](https://www.nuget.org/packages/Scriban.Signed/) NuGet pack
 
 ## License
 
-This software is released under the [BSD-Clause 2 license](http://opensource.org/licenses/BSD-2-Clause). 
+This software is released under the [BSD-Clause 2 license](https://opensource.org/licenses/BSD-2-Clause). 
 
 ## Related projects
 

--- a/src/Scriban.Tests/CustomTemplateLoader.cs
+++ b/src/Scriban.Tests/CustomTemplateLoader.cs
@@ -1,4 +1,6 @@
+#if SCRIBAN_ASYNC
 using System.Threading.Tasks;
+#endif
 using Scriban.Parsing;
 using Scriban.Runtime;
 
@@ -55,10 +57,12 @@ namespace Scriban.Tests
             }
         }
 
+#if SCRIBAN_ASYNC
         public ValueTask<string> LoadAsync(TemplateContext context, SourceSpan callerSpan, string templatePath)
         {
             return new ValueTask<string>(Load(context, callerSpan, templatePath));
         }
+#endif
     }
 
     class LiquidCustomTemplateLoader : ITemplateLoader
@@ -89,9 +93,11 @@ namespace Scriban.Tests
             }
         }
 
+#if SCRIBAN_ASYNC
         public ValueTask<string> LoadAsync(TemplateContext context, SourceSpan callerSpan, string templatePath)
         {
             return new ValueTask<string>(Load(context, callerSpan, templatePath));
         }
+#endif
     }
 }

--- a/src/Scriban.Tests/LiquidTests/IncludeTagTests.cs
+++ b/src/Scriban.Tests/LiquidTests/IncludeTagTests.cs
@@ -2,7 +2,9 @@ using System;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Globalization;
+#if SCRIBAN_ASYNC
 using System.Threading.Tasks;
+#endif
 using Scriban;
 using Scriban.Parsing;
 using Scriban.Runtime;
@@ -52,10 +54,12 @@ namespace DotLiquid.Tests.Tags
                 }
             }
 
+#if SCRIBAN_ASYNC
             public ValueTask<string> LoadAsync(TemplateContext context, SourceSpan callerSpan, string templatePath)
             {
                 return new ValueTask<string>(Load(context, callerSpan, templatePath));
             }
+#endif
         }
 
         internal class TestTemplateFileSystem : ITemplateLoader
@@ -77,10 +81,12 @@ namespace DotLiquid.Tests.Tags
                 return _baseFileSystem.Load(context, callerSpan, templatePath);
             }
 
+#if SCRIBAN_ASYNC
             public ValueTask<string> LoadAsync(TemplateContext context, SourceSpan callerSpan, string templatePath)
             {
                 return _baseFileSystem.LoadAsync(context, callerSpan, templatePath);
             }
+#endif
         }
 
         private class OtherFileSystem : ITemplateLoader
@@ -95,10 +101,12 @@ namespace DotLiquid.Tests.Tags
                 return "from OtherFileSystem";
             }
 
+#if SCRIBAN_ASYNC
             public ValueTask<string> LoadAsync(TemplateContext context, SourceSpan callerSpan, string templatePath)
             {
                 return new ValueTask<string>(Load(context, callerSpan, templatePath));
             }
+#endif
         }
 
         private class InfiniteFileSystem : ITemplateLoader
@@ -113,10 +121,12 @@ namespace DotLiquid.Tests.Tags
                 return "-{% include 'loop' %}";
             }
 
+#if SCRIBAN_ASYNC
             public ValueTask<string> LoadAsync(TemplateContext context, SourceSpan callerSpan, string templatePath)
             {
                 return new ValueTask<string>(Load(context, callerSpan, templatePath));
             }
+#endif
         }
 
         [SetUp]

--- a/src/Scriban.Tests/Scriban.Tests.csproj
+++ b/src/Scriban.Tests/Scriban.Tests.csproj
@@ -1,25 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
-
+    <TargetFrameworks>net35;net40;net45;netcoreapp1.0;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' AND '$(TargetFramework)' != 'net40'">
+    <DefineConstants>$(DefineConstants);SCRIBAN_ASYNC</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Remove="LiquidTests\AssignTests.cs" />
     <Compile Remove="LiquidTests\LiteralTests.cs" />
   </ItemGroup>
-
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' AND '$(TargetFramework)' != 'net40'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Scriban\Scriban.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/Scriban.Tests/TestRuntime.cs
+++ b/src/Scriban.Tests/TestRuntime.cs
@@ -3,11 +3,16 @@
 
 using System;
 using System.Collections.Generic;
+#if !NETCOREAPP1_0 && !NETCOREAPP1_1
+using System.Data;
+#endif
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
+#if SCRIBAN_ASYNC
 using System.Threading.Tasks;
+#endif
 using Newtonsoft.Json;
 using NUnit.Framework;
 using Scriban.Parsing;
@@ -31,7 +36,7 @@ namespace Scriban.Tests
             }
             public static string T(TemplateContext context, object input, params object[] variables)
             {
-                return input + (variables.Length > 0 ? string.Join(",", variables) : string.Empty);
+                return input + (variables.Length > 0 ? string.Join(",", variables.Select(s => s.ToString()).ToArray()) : string.Empty);
             }
         }
 
@@ -111,6 +116,7 @@ end
             TextAssert.AreEqual("22AB", result);
         }
 
+#if SCRIBAN_ASYNC
         [Test]
         public async Task TestAsyncAwait()
         {
@@ -133,6 +139,7 @@ end
 
             Assert.AreEqual("yes", result);
         }
+#endif
 
         [Test]
         public void CheckReturnInsideLoop()
@@ -319,17 +326,18 @@ Tax: {{ 7 | match_tax }}";
             TextAssert.AreEqual("Test with a dynamic yes", result);
         }
 
+#if !NETCOREAPP1_0 && !NETCOREAPP1_1
         [Test]
         public void TestJson()
         {
             // issue: https://github.com/lunet-io/scriban/issues/11
             // fixed: https://github.com/lunet-io/scriban/issues/15
 
-            System.Data.DataTable dataTable = new System.Data.DataTable();
+            DataTable dataTable = new DataTable();
             dataTable.Columns.Add("Column1");
             dataTable.Columns.Add("Column2");
 
-            System.Data.DataRow dataRow = dataTable.NewRow();
+            DataRow dataRow = dataTable.NewRow();
             dataRow["Column1"] = "Hello";
             dataRow["Column2"] = "World";
             dataTable.Rows.Add(dataRow);
@@ -370,13 +378,13 @@ Tax: {{ 7 | match_tax }}";
             var expected =
                 @"
 [
-  { 
+  {
     ""N"": Hello,
     ""M"": World
-    
+
     ""N"": Bonjour,
     ""M"": le monde
-    
+
   },
 ]
 [[[Hello], [World]], [[Bonjour], [le monde]]]
@@ -384,6 +392,7 @@ Tax: {{ 7 | match_tax }}";
 
             TextAssert.AreEqual(expected, result);
         }
+#endif
 
         [Test]
         public void TestScriptObjectImport()

--- a/src/Scriban.Tests/TestRuntime.cs
+++ b/src/Scriban.Tests/TestRuntime.cs
@@ -378,13 +378,13 @@ Tax: {{ 7 | match_tax }}";
             var expected =
                 @"
 [
-  {
+  { 
     ""N"": Hello,
     ""M"": World
-
+    
     ""N"": Bonjour,
     ""M"": le monde
-
+    
   },
 ]
 [[[Hello], [World]], [[Bonjour], [le monde]]]

--- a/src/Scriban.Tests/TextAssert.cs
+++ b/src/Scriban.Tests/TextAssert.cs
@@ -112,7 +112,11 @@ namespace Scriban.Tests
                         return $"\\u{(int) c:X};";
                 }
             }
+#if !NETCOREAPP1_0 && !NETCOREAPP1_1
             return c.ToString(CultureInfo.InvariantCulture);
+#else
+            return c.ToString();
+#endif
         }
     }
 }

--- a/src/Scriban/Functions/HtmlFunctions.cs
+++ b/src/Scriban/Functions/HtmlFunctions.cs
@@ -39,14 +39,13 @@ namespace Scriban.Functions
             {
                 return text;
             }
-#if !NET35 && !NET40 && !PCL328
+#if !NET35 && !NET40
             var stripHtml = new Regex(RegexMatchHtml, RegexOptions.IgnoreCase|RegexOptions.Singleline, context.RegexTimeOut);
 #endif
 
             return stripHtml.Replace(text, string.Empty);
         }
 
-#if !PCL328
         /// <summary>
         /// Escapes a HTML input string (replacing `&amp;` by `&amp;amp;`)
         /// </summary>
@@ -116,22 +115,5 @@ namespace Scriban.Functions
             }
             return Uri.EscapeUriString(text);
         }
-#else
-
-        public static string Escape(string text)
-        {
-            throw new NotSupportedException("This method is not supported by this .NET profile");
-        }
-        
-        public static string UrlEncode(string text)
-        {
-            throw new NotSupportedException("This method is not supported by this .NET profile");
-        }
-
-        public static string UrlEscape(string text)
-        {
-            throw new NotSupportedException("This method is not supported by this .NET profile");
-        }
-#endif
     }
 }

--- a/src/Scriban/Functions/RegexFunctions.cs
+++ b/src/Scriban/Functions/RegexFunctions.cs
@@ -57,7 +57,7 @@ namespace Scriban.Functions
         /// </remarks>
         public static ScriptArray Match(TemplateContext context, string text, string pattern, string options = null)
         {
-#if NET35 || NET40 || PCL328
+#if NET35 || NET40
             var match = Regex.Match(text, pattern, GetOptions(options));
 #else
             var match = Regex.Match(text, pattern, GetOptions(options), context.RegexTimeOut);
@@ -100,7 +100,7 @@ namespace Scriban.Functions
         /// </remarks>
         public static string Replace(TemplateContext context, string text, string pattern, string replace, string options = null)
         {
-#if NET35 || NET40 || PCL328
+#if NET35 || NET40
             return Regex.Replace(text, pattern, replace, GetOptions(options));
 #else
             return Regex.Replace(text, pattern, replace, GetOptions(options), context.RegexTimeOut);
@@ -130,7 +130,7 @@ namespace Scriban.Functions
         /// </remarks>
         public static ScriptArray Split(TemplateContext context, string text, string pattern, string options = null)
         {
-#if NET35 || NET40 || PCL328
+#if NET35 || NET40
             return new ScriptArray(Regex.Split(text, pattern));
 #else
             return new ScriptArray(Regex.Split(text, pattern, GetOptions(options), context.RegexTimeOut));

--- a/src/Scriban/Functions/StringFunctions.cs
+++ b/src/Scriban/Functions/StringFunctions.cs
@@ -1013,11 +1013,11 @@ namespace Scriban.Functions
         public static string Base64Decode(string text)
         {
             var decoded = Convert.FromBase64String(text ?? string.Empty);
-#if NETSTANDARD1_1
+            #if NETSTANDARD1_1
             return Encoding.UTF8.GetString(decoded, 0, decoded.Length);
-#else
+            #else
             return Encoding.UTF8.GetString(decoded);
-#endif
+            #endif
         }
     }
 }

--- a/src/Scriban/Helpers/ReflectionHelper.cs
+++ b/src/Scriban/Helpers/ReflectionHelper.cs
@@ -9,7 +9,7 @@ namespace Scriban.Helpers
 {
     internal static class ReflectionHelper
     {
-#if NET35 || NET40 || PCL328
+#if NET35 || NET40
         public static bool IsPrimitiveOrDecimal(this Type type)
         {
             return type.IsPrimitive || type == typeof(decimal);

--- a/src/Scriban/Helpers/ReflectionHelper.cs
+++ b/src/Scriban/Helpers/ReflectionHelper.cs
@@ -149,16 +149,6 @@ namespace Scriban.Helpers
         {
             return type.DeclaredMethods;
         }
-#if !UAP && !NETSTANDARD2_0
-        public static MethodInfo GetGetMethod(this PropertyInfo prop)
-        {
-            return prop.GetMethod;
-        }
-        public static MethodInfo GetSetMethod(this PropertyInfo prop)
-        {
-            return prop.SetMethod;
-        }
-#endif
 #endif
     }
 }

--- a/src/Scriban/Runtime/Accessors/TypedObjectAccessor.cs
+++ b/src/Scriban/Runtime/Accessors/TypedObjectAccessor.cs
@@ -109,7 +109,7 @@ namespace Scriban.Runtime.Accessors
                     var keep = property.GetCustomAttribute<ScriptMemberIgnoreAttribute>() == null;
 
                     // Workaround with .NET Core, extension method is not working (retuning null despite doing property.GetMethod), so we need to inline it here
-#if NET35 || NET40 || PCL328
+#if NET35 || NET40
                     var getMethod = property.GetGetMethod();
 #else
                     var getMethod = property.GetMethod;

--- a/src/Scriban/Runtime/Accessors/TypedObjectAccessor.cs
+++ b/src/Scriban/Runtime/Accessors/TypedObjectAccessor.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// Licensed under the BSD-Clause 2 license. 
+// Licensed under the BSD-Clause 2 license.
 // See license.txt file in the project root for full license information.
 using System;
 using System.Collections;

--- a/src/Scriban/Runtime/CustomFunction.Generated.cs
+++ b/src/Scriban/Runtime/CustomFunction.Generated.cs
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------------
-// This file was automatically generated - 11.01.2019 17:53:05 by Scriban.CodeGen
+// This file was automatically generated - 02/09/2019 14:39:16 by Scriban.CodeGen
 // DOT NOT EDIT THIS FILE MANUALLY
 // ----------------------------------------------------------------------------------
 
@@ -18,49 +18,49 @@ namespace Scriban.Runtime
 
         static DynamicCustomFunction()
         {
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Contains)), method => new Functionbool_IEnumerable_object(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.MathFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.MathFunctions.IsNumber)), method => new Functionbool_object(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Contains)), method => new Functionbool_string_string(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.DateTimeFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.DateTimeFunctions.Now)), method => new FunctionDateTime(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.DateTimeFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.DateTimeFunctions.AddDays)), method => new FunctionDateTime_DateTime_double(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.DateTimeFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.DateTimeFunctions.AddMonths)), method => new FunctionDateTime_DateTime_int(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.MathFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.MathFunctions.Ceil)), method => new Functiondouble_double(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.MathFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.MathFunctions.Round)), method => new Functiondouble_double_int___Opt(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Reverse)), method => new FunctionIEnumerable_IEnumerable(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.AddRange)), method => new FunctionIEnumerable_IEnumerable_IEnumerable(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Split)), method => new FunctionIEnumerable_string_string(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Sort)), method => new FunctionIEnumerable_TemplateContext_SourceSpan_object_string___Opt(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Map)), method => new FunctionIEnumerable_TemplateContext_SourceSpan_object_string(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.RemoveAt)), method => new FunctionIList_IList_int(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.InsertAt)), method => new FunctionIList_IList_int_object(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Add)), method => new FunctionIList_IList_object(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Size)), method => new Functionint_IEnumerable(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Size)), method => new Functionint_string(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ObjectFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ObjectFunctions.Size)), method => new Functionint_TemplateContext_SourceSpan_object(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.First)), method => new Functionobject_IEnumerable(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ObjectFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ObjectFunctions.Default)), method => new Functionobject_object_object(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.MathFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.MathFunctions.DividedBy)), method => new Functionobject_TemplateContext_SourceSpan_double_object(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Cycle)), method => new Functionobject_TemplateContext_SourceSpan_IList_object___Opt(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.MathFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.MathFunctions.Abs)), method => new Functionobject_TemplateContext_SourceSpan_object(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.MathFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.MathFunctions.Minus)), method => new Functionobject_TemplateContext_SourceSpan_object_object(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.ToInt)), method => new Functionobject_TemplateContext_string(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Compact)), method => new FunctionScriptArray_IEnumerable(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Limit)), method => new FunctionScriptArray_IEnumerable_int(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.RegexFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.RegexFunctions.Match)), method => new FunctionScriptArray_TemplateContext_string_string_string___Opt(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Pluralize)), method => new Functionstring_int_string_string(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ObjectFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ObjectFunctions.Typeof)), method => new Functionstring_object(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.HtmlFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.HtmlFunctions.Escape)), method => new Functionstring_string(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.PadLeft)), method => new Functionstring_string_int(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Slice)), method => new Functionstring_string_int_int___Opt(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Truncate)), method => new Functionstring_string_int_string___Opt(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Append)), method => new Functionstring_string_string(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Replace)), method => new Functionstring_string_string_string(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Join)), method => new Functionstring_TemplateContext_SourceSpan_IEnumerable_string(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.MathFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.MathFunctions.Format)), method => new Functionstring_TemplateContext_SourceSpan_object_string_string___Opt(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.HtmlFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.HtmlFunctions.Strip)), method => new Functionstring_TemplateContext_string(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.RegexFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.RegexFunctions.Replace)), method => new Functionstring_TemplateContext_string_string_string_string___Opt(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.TimeSpanFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.TimeSpanFunctions.FromDays)), method => new FunctionTimeSpan_double(method));
-            BuiltinFunctions.Add(typeof(Scriban.Functions.TimeSpanFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.TimeSpanFunctions.Parse)), method => new FunctionTimeSpan_string(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Contains)), method => new Functionbool_IEnumerable_object(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.MathFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.MathFunctions.IsNumber)), method => new Functionbool_object(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Contains)), method => new Functionbool_string_string(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.DateTimeFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.DateTimeFunctions.Now)), method => new FunctionDateTime(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.DateTimeFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.DateTimeFunctions.AddDays)), method => new FunctionDateTime_DateTime_double(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.DateTimeFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.DateTimeFunctions.AddMonths)), method => new FunctionDateTime_DateTime_int(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.MathFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.MathFunctions.Ceil)), method => new Functiondouble_double(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.MathFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.MathFunctions.Round)), method => new Functiondouble_double_int___Opt(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Reverse)), method => new FunctionIEnumerable_IEnumerable(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.AddRange)), method => new FunctionIEnumerable_IEnumerable_IEnumerable(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Split)), method => new FunctionIEnumerable_string_string(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Sort)), method => new FunctionIEnumerable_TemplateContext_SourceSpan_object_string___Opt(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Map)), method => new FunctionIEnumerable_TemplateContext_SourceSpan_object_string(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.RemoveAt)), method => new FunctionIList_IList_int(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.InsertAt)), method => new FunctionIList_IList_int_object(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Add)), method => new FunctionIList_IList_object(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Size)), method => new Functionint_IEnumerable(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Size)), method => new Functionint_string(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ObjectFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ObjectFunctions.Size)), method => new Functionint_TemplateContext_SourceSpan_object(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.First)), method => new Functionobject_IEnumerable(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ObjectFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ObjectFunctions.Default)), method => new Functionobject_object_object(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.MathFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.MathFunctions.DividedBy)), method => new Functionobject_TemplateContext_SourceSpan_double_object(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Cycle)), method => new Functionobject_TemplateContext_SourceSpan_IList_object___Opt(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.MathFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.MathFunctions.Abs)), method => new Functionobject_TemplateContext_SourceSpan_object(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.MathFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.MathFunctions.Minus)), method => new Functionobject_TemplateContext_SourceSpan_object_object(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.ToInt)), method => new Functionobject_TemplateContext_string(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Compact)), method => new FunctionScriptArray_IEnumerable(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Limit)), method => new FunctionScriptArray_IEnumerable_int(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.RegexFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.RegexFunctions.Match)), method => new FunctionScriptArray_TemplateContext_string_string_string___Opt(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Pluralize)), method => new Functionstring_int_string_string(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ObjectFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ObjectFunctions.Typeof)), method => new Functionstring_object(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.HtmlFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.HtmlFunctions.Escape)), method => new Functionstring_string(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.PadLeft)), method => new Functionstring_string_int(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Slice)), method => new Functionstring_string_int_int___Opt(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Truncate)), method => new Functionstring_string_int_string___Opt(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Append)), method => new Functionstring_string_string(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.StringFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.StringFunctions.Replace)), method => new Functionstring_string_string_string(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.ArrayFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.ArrayFunctions.Join)), method => new Functionstring_TemplateContext_SourceSpan_IEnumerable_string(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.MathFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.MathFunctions.Format)), method => new Functionstring_TemplateContext_SourceSpan_object_string_string___Opt(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.HtmlFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.HtmlFunctions.Strip)), method => new Functionstring_TemplateContext_string(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.RegexFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.RegexFunctions.Replace)), method => new Functionstring_TemplateContext_string_string_string_string___Opt(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.TimeSpanFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.TimeSpanFunctions.FromDays)), method => new FunctionTimeSpan_double(method));
+            BuiltinFunctionDelegates.Add(typeof(Scriban.Functions.TimeSpanFunctions).GetTypeInfo().GetDeclaredMethod(nameof(Scriban.Functions.TimeSpanFunctions.Parse)), method => new FunctionTimeSpan_string(method));
 
         }
 
@@ -294,10 +294,6 @@ namespace Scriban.Runtime
                         argOrderedIndex++;
                     }
 
-                    switch (argIndex)
-                    {
-
-                    }
                 }
 
                 if (argMask != (1 << 0) - 1)

--- a/src/Scriban/Runtime/DynamicCustomFunction.cs
+++ b/src/Scriban/Runtime/DynamicCustomFunction.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// Licensed under the BSD-Clause 2 license. 
+// Licensed under the BSD-Clause 2 license.
 // See license.txt file in the project root for full license information.
 
 using System;
@@ -19,7 +19,7 @@ namespace Scriban.Runtime
     /// </summary>
     public abstract partial class DynamicCustomFunction : IScriptCustomFunction
     {
-        private static readonly Dictionary<MethodInfo, Func<MethodInfo, DynamicCustomFunction>> BuiltinFunctions = new Dictionary<MethodInfo, Func<MethodInfo, DynamicCustomFunction>>(MethodComparer.Default);
+        private static readonly Dictionary<MethodInfo, Func<MethodInfo, DynamicCustomFunction>> BuiltinFunctionDelegates = new Dictionary<MethodInfo, Func<MethodInfo, DynamicCustomFunction>>(MethodComparer.Default);
 
         /// <summary>
         /// Gets the reflection method associated to this dynamic call.
@@ -88,8 +88,7 @@ namespace Scriban.Runtime
         {
             if (method == null) throw new ArgumentNullException(nameof(method));
 
-            Func<MethodInfo, DynamicCustomFunction> newFunction;
-            if (target == null && method.IsStatic && BuiltinFunctions.TryGetValue(method, out newFunction))
+            if (target == null && method.IsStatic && BuiltinFunctionDelegates.TryGetValue(method, out var newFunction))
             {
                 return newFunction(method);
             }
@@ -114,7 +113,7 @@ namespace Scriban.Runtime
         }
 
 
-    
+
         private class MethodComparer : IEqualityComparer<MethodInfo>
         {
             public static readonly MethodComparer Default = new MethodComparer();

--- a/src/Scriban/Runtime/ScriptObjectExtensions.cs
+++ b/src/Scriban/Runtime/ScriptObjectExtensions.cs
@@ -243,7 +243,7 @@ namespace Scriban.Runtime
                     foreach (var property in typeInfo.GetDeclaredProperties())
                     {
                         // Workaround with .NET Core, extension method is not working (retuning null despite doing property.GetMethod), so we need to inline it here
-#if NET35 || NET40 || PCL328
+#if NET35 || NET40
                         var getMethod = property.GetGetMethod();
 #else
                         var getMethod = property.GetMethod;

--- a/src/Scriban/Scriban.csproj
+++ b/src/Scriban/Scriban.csproj
@@ -18,6 +18,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/lunet-io/scriban/master/img/scriban.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/lunet-io/scriban</PackageProjectUrl>
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.1' ">1.6.1</NetStandardImplicitPackageVersion>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--Add support for sourcelink-->

--- a/src/Scriban/Scriban.csproj
+++ b/src/Scriban/Scriban.csproj
@@ -17,7 +17,7 @@
     <PackageReleaseNotes>https://github.com/lunet-io/scriban/blob/master/changelog.md</PackageReleaseNotes>
     <PackageIconUrl>https://raw.githubusercontent.com/lunet-io/scriban/master/img/scriban.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/lunet-io/scriban</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/lunet-io/scriban/blob/master/license.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--Add support for sourcelink-->

--- a/src/Scriban/Scriban.csproj
+++ b/src/Scriban/Scriban.csproj
@@ -9,7 +9,7 @@
     <BuildNumber>005</BuildNumber>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <Authors>Alexandre Mutel</Authors>
-    <TargetFrameworks>net35;net40;net45;net471;netstandard1.1;netstandard1.3;netstandard2.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Scriban</AssemblyName>
     <PackageId>Scriban</PackageId>
     <PackageId Condition="'$(SignAssembly)' == 'true'">Scriban.Signed</PackageId>
@@ -18,23 +18,12 @@
     <PackageIconUrl>https://raw.githubusercontent.com/lunet-io/scriban/master/img/scriban.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/lunet-io/scriban</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/lunet-io/scriban/blob/master/license.txt</PackageLicenseUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.1' ">1.6.1</NetStandardImplicitPackageVersion>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--Add support for sourcelink-->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' OR '$(TargetFramework)' == 'net40'">
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Web" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' AND '$(TargetFramework)' != 'net40'">
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
-  </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' AND '$(TargetFramework)' != 'net40'">
     <DefineConstants>$(DefineConstants);SCRIBAN_ASYNC</DefineConstants>
   </PropertyGroup>
@@ -42,11 +31,15 @@
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
-  <!-- Special packages and imports for UWP support -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net35'">
+    <Reference Include="System.Web" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' AND '$(TargetFramework)' != 'net40'">
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.9" PrivateAssets="all" />
     <!--Add support for sourcelink-->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
   </ItemGroup>
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/Scriban/Scriban.csproj
+++ b/src/Scriban/Scriban.csproj
@@ -9,7 +9,7 @@
     <BuildNumber>005</BuildNumber>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <Authors>Alexandre Mutel</Authors>
-    <TargetFrameworks>net35;net40;net45;net471;netstandard1.1;netstandard1.3;netstandard2.0;uap10.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net471;netstandard1.1;netstandard1.3;netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Scriban</AssemblyName>
     <PackageId>Scriban</PackageId>
     <PackageId Condition="'$(SignAssembly)' == 'true'">Scriban.Signed</PackageId>
@@ -33,38 +33,10 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'net35' AND '$(TargetFramework)' != 'net40'">
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net35' AND '$(TargetFramework)' != 'net40' AND '$(TargetFramework)' != 'net471'">
-    <PackageReference Include="System.Threading.Tasks.Extensions">
-      <Version>4.5.1</Version>
-    </PackageReference>
-  </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45'">
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net35' AND '$(TargetFramework)' != 'net40'">
     <DefineConstants>$(DefineConstants);SCRIBAN_ASYNC</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net471' ">
-    <DefineConstants>$(DefineConstants);SCRIBAN_ASYNC</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-    <DefineConstants>$(DefineConstants);SCRIBAN_ASYNC</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <DefineConstants>$(DefineConstants);SCRIBAN_ASYNC</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);SCRIBAN_ASYNC</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <DefineConstants>$(DefineConstants);SCRIBAN_ASYNC</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
-  </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition="'$(TargetPlatformVersion)' == ''">10.0.10240.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion Condition="'$(TargetPlatformMinVersion)' == ''">10.0.10240.0</TargetPlatformMinVersion>
-    <DefineConstants>$(DefineConstants);UAP;SCRIBAN_ASYNC</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(SignAssembly)' == 'true' ">
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
@@ -75,14 +47,6 @@
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.9" PrivateAssets="all" />
     <!--Add support for sourcelink-->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform " Version="6.1.9" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Threading.Tasks.Extensions">
-      <HintPath>..\..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\system.threading.tasks.extensions\4.5.1\ref\netstandard1.0\System.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/Scriban/Syntax/ScriptLoopStatementBase.cs
+++ b/src/Scriban/Syntax/ScriptLoopStatementBase.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Alexandre Mutel. All rights reserved.
-// Licensed under the BSD-Clause 2 license. 
+// Licensed under the BSD-Clause 2 license.
 // See license.txt file in the project root for full license information.
 
 #if SCRIBAN_ASYNC
@@ -63,7 +63,7 @@ namespace Scriban.Syntax
         {
             // Notify the context that we enter a loop block (used for variable with scope Loop)
             object result = null;
-            context.EnterLoop(this);            
+            context.EnterLoop(this);
             try
             {
                 result = EvaluateImpl(context);
@@ -87,12 +87,14 @@ namespace Scriban.Syntax
 #if SCRIBAN_ASYNC
         protected abstract ValueTask<object> EvaluateImplAsync(TemplateContext context);
 
-        protected virtual async ValueTask BeforeLoopAsync(TemplateContext context)
+        protected virtual ValueTask BeforeLoopAsync(TemplateContext context)
         {
+            return new ValueTask();
         }
 
-        protected virtual async ValueTask AfterLoopAsync(TemplateContext context)
+        protected virtual ValueTask AfterLoopAsync(TemplateContext context)
         {
+            return new ValueTask();
         }
 #endif
     }


### PR DESCRIPTION
This PR:

* Closes #133 by targeting only the frameworks the maintainer specified.
* Ports the unit tests to .NET 3.5, .NET 4, and the older .NET Core versions that are still supported.
* Fixes the code generator to work with the new project format (the executable is one directory deeper).
* Adds [SPDX license metadata](https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg) to the project file.