### PR TITLE
Clarify the error message for a function that was not found.

### DIFF
--- a/src/Scriban/Syntax/ScriptFunctionCall.cs
+++ b/src/Scriban/Syntax/ScriptFunctionCall.cs
@@ -31,7 +31,7 @@ namespace Scriban.Syntax
             // Throw an exception if the target function is null
             if (targetFunction == null)
             {
-                throw new ScriptRuntimeException(Target.Span, $"The target `{Target}` function is null");
+                throw new ScriptRuntimeException(Target.Span, $"The function `{Target}` was not found");
             }
 
             return Call(context, this, targetFunction, context.AllowPipeArguments, Arguments);


### PR DESCRIPTION
The previous error message was very vague. This vagueness was the cause for [quite a tricky bug I had encountered](https://devrant.com/rants/2038602).