### PR TITLE
Added upcase string filter to list of built-in Liquid functions

### DIFF
--- a/src/Scriban/Functions/LiquidBuiltinsFunctions.cs
+++ b/src/Scriban/Functions/LiquidBuiltinsFunctions.cs
@@ -78,6 +78,7 @@ namespace Scriban.Functions
                 case "truncate": target = "string"; member = "truncate"; return true;
                 case "truncatewords": target = "string"; member = "truncatewords"; return true;
                 case "uniq": target = "array"; member = "uniq"; return true;
+                case "upcase": target = "string"; member = "upcase"; return true;
                 case "contains": target = "array"; member = "contains"; return true;
             }
 
@@ -145,6 +146,7 @@ namespace Scriban.Functions
                 SetValue("truncate", str["truncate"], true);
                 SetValue("truncatewords", str["truncatewords"], true);
                 SetValue("uniq", array["uniq"], true);
+                SetValue("upcase", str["upcase"], true);
                 SetValue("contains", array["contains"], true);
 
                 this.Import(typeof(LiquidBuiltinsFunctions), ScriptMemberImportFlags.All);


### PR DESCRIPTION
I've added `upcase` to the list of Liquid filters, hopefully this change is ok.  I couldn't find any existing tests for the Liquid filters, so I assume this is all I need to do.  Please let me know if I've followed appropriate PR convention for this repo.

This PR is for this issue: #242 