### PR TITLE
fix rendering of conditional expression in table

### DIFF
--- a/doc/language.md
+++ b/doc/language.md
@@ -706,12 +706,13 @@ A conditional expression produces a boolean by comparing a left and right value.
 
 They work with both `numbers`, `strings` and datetimes.
 
-You can combine conditionnal expressions with `&&` (and operator) and `||` (or operator)
+You can combine conditional expressions with `&&` (and operator) and `||` (or operator).
+Unlike in `javascript` it always returns `boolean` and never `<left>` or `<right>`.
 
 |Operator            | Description
 |--------------------|------------
-| `<left> && <right>` | Is left true and right true? 
-| `<left> || <right>` | Is left true or right true?
+| `<left> && <right>` | Is left true and right true?
+| `<left> \|\| <right>` | Is left true or right true?
 
 [:top:](#language)
 ### 8.6 Unary expressions

--- a/doc/language.md
+++ b/doc/language.md
@@ -381,6 +381,7 @@ b.x
 1
 ```
 
+[:top:](#language)
 ### 4.2 The special variable `empty`
 
 The `empty` variable represents simply an empty object. It is mainly relevant to be compatible with liquid, by providing a way to compare an object with the `empty` object to check if it is empty or not:
@@ -544,6 +545,7 @@ a.x + a[0]
 yes5
 ```
 
+[:top:](#language)
 ### 6.2 The special `size` property
 
 Arrays have a `size` property that can be used to query the number of elements in the array:
@@ -976,7 +978,7 @@ Like the `if` statement, the `expression` is evaluated to a boolean.
 
 #### `tablerow <variable> in <expression> ... end`
 
-This function generates HTML rows compatible with an HTML table. Must be wrapped in an opening <table> and closing </table> HTML tags.
+This function generates HTML rows compatible with an HTML table. Must be wrapped in an opening `<table>` and closing `</table>` HTML tags.
 
 This statement is mainly for compatibility reason with the liquid `tablerow` tag.
 It has overall the same syntax as a `for` statement (supporting the same parameters).


### PR DESCRIPTION
Expression `||` were treated as table column delimiter so it should be escaped to be rendered as expected.
Fixed spelling, added note that conditional expressions always returns boolean but not its members.