### PR TITLE
AST : fix parent node span does not include all its children

### DIFF
--- a/src/Scriban.Tests/TestFiles/100-expressions/101-assign-complex-error1.out.txt
+++ b/src/Scriban.Tests/TestFiles/100-expressions/101-assign-complex-error1.out.txt
@@ -1,3 +1,3 @@
-text(5,7) : error : Error while parsing assign expression: Expression is only allowed for a top level assignment in: <target_expression> = <value_expression>
-text(5,11) : error : Error while parsing assign expression: Expression is only allowed for a top level assignment in: <target_expression> = <value_expression>
-text(5,20) : error : Error while parsing assign expression: Expression is only allowed for a top level assignment in: <target_expression> = <value_expression>
+text(5,5) : error : Error while parsing assign expression: Expression is only allowed for a top level assignment in: <target_expression> = <value_expression>
+text(5,9) : error : Error while parsing assign expression: Expression is only allowed for a top level assignment in: <target_expression> = <value_expression>
+text(5,18) : error : Error while parsing assign expression: Expression is only allowed for a top level assignment in: <target_expression> = <value_expression>

--- a/src/Scriban.Tests/TestFiles/200-statements/201-if-else-error5.out.txt
+++ b/src/Scriban.Tests/TestFiles/200-statements/201-if-else-error5.out.txt
@@ -1,1 +1,1 @@
-text(5,6) : error : Error while parsing assign expression: Expression is only allowed for a top level assignment in: <target_expression> = <value_expression>
+text(5,4) : error : Error while parsing assign expression: Expression is only allowed for a top level assignment in: <target_expression> = <value_expression>

--- a/src/Scriban.Tests/TestFiles/200-statements/205-case-when-statement-expression-error.out.txt
+++ b/src/Scriban.Tests/TestFiles/200-statements/205-case-when-statement-expression-error.out.txt
@@ -1,1 +1,1 @@
-text(3,15) : error : Error while parsing assign expression: Expression is only allowed for a top level assignment in: <target_expression> = <value_expression>
+text(3,6) : error : Error while parsing assign expression: Expression is only allowed for a top level assignment in: <target_expression> = <value_expression>

--- a/src/Scriban.Tests/TestFiles/200-statements/221-while-error2.out.txt
+++ b/src/Scriban.Tests/TestFiles/200-statements/221-while-error2.out.txt
@@ -1,1 +1,1 @@
-text(2,9) : error : Error while parsing assign expression: Expression is only allowed for a top level assignment in: <target_expression> = <value_expression>
+text(2,7) : error : Error while parsing assign expression: Expression is only allowed for a top level assignment in: <target_expression> = <value_expression>

--- a/src/Scriban/Parsing/Parser.Expressions.cs
+++ b/src/Scriban/Parsing/Parser.Expressions.cs
@@ -309,6 +309,11 @@ namespace Scriban.Parsing
                         {
                             var assignExpression = Open<ScriptAssignExpression>();
 
+                            if (leftOperand != null)
+                            {                                
+                                assignExpression.Span.Start = leftOperand.Span.Start;
+                            }
+
                             if (leftOperand != null && !(leftOperand is IScriptVariablePath) || functionCall != null || _expressionLevel > 1 || !allowAssignment)
                             {
                                 // unit test: 101-assign-complex-error1.txt

--- a/src/Scriban/Parsing/Parser.Expressions.cs
+++ b/src/Scriban/Parsing/Parser.Expressions.cs
@@ -685,6 +685,10 @@ namespace Scriban.Parsing
                         }
 
                         var pipeCall = Open<ScriptPipeCall>();
+                        if (leftOperand != null)
+                        {
+                            pipeCall.Span.Start = leftOperand.Span.Start;
+                        }
                         pipeCall.From = leftOperand;
 
                         pipeCall.PipeToken = ParseToken(Current.Type); // skip | or |>

--- a/src/Scriban/Parsing/Parser.cs
+++ b/src/Scriban/Parsing/Parser.cs
@@ -133,6 +133,10 @@ namespace Scriban.Parsing
             }
 
             page.Body = ParseBlockStatement(null);
+            if (page.Body != null)
+            {
+                page.Span = page.Body.Span;
+            }
 
             // Flush any pending trivias
             if (_isKeepTrivia && _lastTerminalWithTrivias != null)

--- a/src/Scriban/Parsing/SourceSpan.cs
+++ b/src/Scriban/Parsing/SourceSpan.cs
@@ -23,6 +23,8 @@ namespace Scriban.Parsing
 
         public TextPosition End { get; set; }
 
+        public int Length => End.Offset - Start.Offset + 1;
+
         public override string ToString()
         {
             return $"{FileName}({Start})-({End})";


### PR DESCRIPTION
Solution for problems reported in #279.

Also as a bonus, it would be nice to have Length property on SourceSpan struct, which was added in last check-in.
